### PR TITLE
Add rebalancing start date

### DIFF
--- a/zfs-inplace-rebalancing.sh
+++ b/zfs-inplace-rebalancing.sh
@@ -229,7 +229,7 @@ done;
 
 root_path=$1
 
-color_echo "$Cyan" "Start rebalancing:"
+color_echo "$Cyan" "Start rebalancing $(date):"
 color_echo "$Cyan" "  Path: ${root_path}"
 color_echo "$Cyan" "  Rebalancing Passes: ${passes_flag}"
 color_echo "$Cyan" "  Use Checksum: ${checksum_flag}"


### PR DESCRIPTION
As the rebalancing process can take days and sometimes is interrupted, it would be beneficial to retain the time the process has started in the log. This is a trivial and POSIX-complaint change. To avoid incompatibilities between different shell built-ins I deliberately didn't specify any data/time format.