### PR TITLE
Update dependency documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ chmod +x ./zfs-inplace-rebalancing.sh
 ```
 
 Dependencies:
-* `pacman -S bc` - used for percentage calculation
+* `perl` - it should be available on most systems by default
 
 ## Usage
 


### PR DESCRIPTION
`bc` is no longer used since https://github.com/markusressel/zfs-inplace-rebalancing/pull/24; updated `README` to reflect.