### PR TITLE
Make database operations 30x faster by using SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 test.log
 error.log
 rebalance_db.txt
+rebalance.db
 testing_data

--- a/convert-legacy-db.sh
+++ b/convert-legacy-db.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -eu
+
+####
+#### This script converts legacy "rebalance_db.txt" database file to new "rebalance.db" format
+#### It utilizes a CSV intermediary as this is the fastest way of ingesting a large dataset into SQLite
+####
+
+rebalance_db_file_name='rebalance_db.txt'
+rebalance_sqldb_file='rebalance.db'
+rebalance_csv_tmp='rebalance.csv_tmp'
+
+echo "Importing ${rebalance_db_file_name} into ${rebalance_sqldb_file}..."
+
+echo "Creating SQL database at ${rebalance_sqldb_file}"
+# ensures it's FOR SURE an empty db
+sqlite3 "${rebalance_sqldb_file}" 'create table balancing (file string primary key, passes integer)'
+
+total=$(($(cat "${rebalance_db_file_name}" | wc -l) / 2))
+done=0
+path=''
+echo "Generating CSV at ${rebalance_csv_tmp}"
+echo -n > "${rebalance_csv_tmp}"
+while IFS="" read -r line || [ -n "$line" ]; do
+    if [[ -z "${path}" ]]; then
+        path="${line}"
+        continue
+    fi
+
+    echo "\"${path//\"/\"\"}\",${line}" >> "${rebalance_csv_tmp}"
+    path=''
+    echo -e -n "\r=> Generated $((done+=1)) of ${total} lines"
+done < "./${rebalance_db_file_name}"
+echo -e "\r=> Processed ${total} items to CSV at ${rebalance_csv_tmp}"
+
+echo "Importing data to ${rebalance_sqldb_file}..."
+sqlite3 "${rebalance_sqldb_file}" '.mode csv' ".import ${rebalance_csv_tmp} balancing"
+
+echo "Optimizing database..."
+sqlite3 "${rebalance_sqldb_file}" 'VACUUM'
+
+echo 'Cleaning up...'
+rm "${rebalance_csv_tmp}"
+mv "${rebalance_db_file_name}" "${rebalance_sqldb_file}_legacy"

--- a/testing.sh
+++ b/testing.sh
@@ -14,7 +14,7 @@ function prepare() {
   # cleanup
   rm -f $log_std_file
   rm -f $log_error_file
-  rm -f rebalance_db.txt
+  rm -f rebalance.db
   rm -rf $test_pool_data_path
 
   # setup

--- a/zfs-inplace-rebalancing.sh
+++ b/zfs-inplace-rebalancing.sh
@@ -5,8 +5,13 @@ set -e
 # exit on undeclared variable
 set -u
 
-# file used to track processed files
-rebalance_db_file_name="rebalance_db.txt"
+# processed files database runtime variables
+rebalance_db_file_name="rebalance.db"
+
+# keeps changes before these are persisted to the database
+rebalance_db_cache='' #database filename
+rebalance_db_save_interval=60 # how often changes are persisted to the database in seconds
+rebalance_db_last_save=$SECONDS # when the database was last persisted
 
 # index used for progress
 current_index=0
@@ -36,24 +41,63 @@ function color_echo () {
     echo -e "${color}${text}${Color_Off}"
 }
 
+# Loads existing rebalance database, or creates a new one. Requires no parameters.
+function init_database () {
+  if [[ "${passes_flag}" -le 0 ]]; then
+    echo "skipped (--passes <= 0 requested)"
+    return
+  fi
 
+  if [[ ! -r "${rebalance_db_file_name}" ]]; then # database unreadable => either no db or no permissions
+    # try to create a new db - if this is a permission problem this will crash [as intended]
+    sqlite3 "${rebalance_db_file_name}" "CREATE TABLE balancing (file string primary key, passes integer)"
+    echo "initialized in ${rebalance_db_file_name}"
+  else # db is readable - do a simple sanity check to make sure it isn't broken/locked
+    local balanced
+    balanced=$(sqlite3 "${rebalance_db_file_name}" "SELECT COUNT(*) FROM balancing")
+    echo "found ${balanced} records in ${rebalance_db_file_name}"
+  fi
+}
+
+# Provides number of already completed balancing passes for a given file
+# Use: get_rebalance_count "/path/to/file"
+# Output: a non-negative integer
 function get_rebalance_count () {
-    file_path=$1
+    local count
+    count=$(sqlite3 "${rebalance_db_file_name}" "SELECT passes FROM balancing WHERE file = '${1//'/\'}'")
+    echo "${count:-0}"
+}
 
-    line_nr=$(grep -xF -n "${file_path}" "./${rebalance_db_file_name}" | head -n 1 | cut -d: -f1)
-    if [ -z "${line_nr}" ]; then
-        echo "0"
-        return
-    else
-        rebalance_count_line_nr="$((line_nr + 1))"
-        rebalance_count=$(awk "NR == ${rebalance_count_line_nr}" "./${rebalance_db_file_name}")
-        echo "${rebalance_count}"
-        return
+function persist_database () {
+  color_echo "${Cyan}" "Flushing database changes..."
+  sqlite3 "${rebalance_db_file_name}" <<< "BEGIN TRANSACTION;${rebalance_db_cache};COMMIT;"
+  rebalance_db_cache=''
+  rebalance_db_last_save=$SECONDS
+}
+
+# Sets number of completed balancing passes for a given file
+# Use: set_rebalance_count "/path/to/file" 123
+function set_rebalance_count () {
+    rebalance_db_cache="${rebalance_db_cache};INSERT OR REPLACE INTO balancing VALUES('${1//'/\'}', $2);"
+    color_echo "${Green}" "File $1 completed $2 rebalance cycles"
+
+    # this is slightly "clever", as there's no way to access monotonic time in shell.
+    # $SECONDS contains a wall clock time since shell starting, but it's affected
+    #  by timezones and system time changes. "time_since_last" will calculate absolute
+    #  difference since last DB save. It may not be correct, but unless the time
+    #  changes constantly, it will save *at least* every $rebalance_db_save_time
+    local time_now=$SECONDS
+    local time_since_last=$(($time_now >= $rebalance_db_last_save ? $time_now - $rebalance_db_last_save : $rebalance_db_last_save - $time_now))
+    if [[ $time_since_last -gt $rebalance_db_save_interval ]]; then
+        persist_database
     fi
 }
 
-# rebalance a specific file
+# Rebalance a specific file
+# Use: rebalance "/path/to/file"
+# Output: log lines
 function rebalance () {
+    local file_path
     file_path=$1
 
     # check if file has >=2 links in the case of --skip-hardlinks
@@ -69,22 +113,26 @@ function rebalance () {
     fi
 
     current_index="$((current_index + 1))"
-    progress_percent=$(perl -e "printf('%0.2f', ${current_index}*100/${file_count})") 
-    color_echo "${Cyan}" "Progress -- Files: ${current_index}/${file_count} (${progress_percent}%)" 
+    progress_percent=$(perl -e "printf('%0.2f', ${current_index}*100/${file_count})")
+    color_echo "${Cyan}" "Progress -- Files: ${current_index}/${file_count} (${progress_percent}%)"
 
     if [[ ! -f "${file_path}" ]]; then
-        color_echo "${Yellow}" "File is missing, skipping: ${file_path}" 
+        color_echo "${Yellow}" "File is missing, skipping: ${file_path}"
     fi
 
-    if [ "${passes_flag}" -ge 1 ]; then
-        # check if target rebalance count is reached
+
+    if [[ "${passes_flag}" -ge 1 ]]; then
+        # this count is reused later to update database
+        local rebalance_count
         rebalance_count=$(get_rebalance_count "${file_path}")
-        if [ "${rebalance_count}" -ge "${passes_flag}" ]; then
-        color_echo "${Yellow}" "Rebalance count (${passes_flag}) reached, skipping: ${file_path}"
-        return
+
+        # check if target rebalance count is reached
+        if [[ "${rebalance_count}" -ge "${passes_flag}" ]]; then
+          color_echo "${Yellow}" "Rebalance count of ${passes_flag} reached (${rebalance_count}), skipping: ${file_path}"
+          return
         fi
     fi
-   
+
     tmp_extension=".balance"
     tmp_file_path="${file_path}${tmp_extension}"
 
@@ -172,17 +220,7 @@ function rebalance () {
     mv "${tmp_file_path}" "${file_path}"
 
     if [ "${passes_flag}" -ge 1 ]; then
-        # update rebalance "database"
-        line_nr=$(grep -xF -n "${file_path}" "./${rebalance_db_file_name}" | head -n 1 | cut -d: -f1)
-        if [ -z "${line_nr}" ]; then
-        rebalance_count=1
-        echo "${file_path}" >> "./${rebalance_db_file_name}"
-        echo "${rebalance_count}" >> "./${rebalance_db_file_name}"
-        else
-        rebalance_count_line_nr="$((line_nr + 1))"
-        rebalance_count="$((rebalance_count + 1))"
-        sed -i "${rebalance_count_line_nr}s/.*/${rebalance_count}/" "./${rebalance_db_file_name}"
-        fi
+        set_rebalance_count "${file_path}" $((rebalance_count + 1))
     fi
 }
 
@@ -224,14 +262,21 @@ while true ; do
         *)
             break
         ;;
-    esac 
+    esac
 done;
 
 root_path=$1
 
-color_echo "$Cyan" "Start rebalancing $(date):"
+# ensure we don't do something unexpected
+if [[ -r "rebalance_db.txt" ]]; then
+  color_echo "${Red}" 'Found legacy database file in "rebalance_db.txt". To avoid possible unintended operations the process will terminate. You can either convert the legacy database using "convert-legacy-db.sh" script, or simply delete/rename "rebalance_db.txt"'
+  exit 2
+fi
+
+color_echo "$Cyan" "Start rebalancing:"
 color_echo "$Cyan" "  Path: ${root_path}"
 color_echo "$Cyan" "  Rebalancing Passes: ${passes_flag}"
+color_echo "$Cyan" "  Rebalancing DB: $(init_database)"
 color_echo "$Cyan" "  Use Checksum: ${checksum_flag}"
 color_echo "$Cyan" "  Skip Hardlinks: ${skip_hardlinks_flag}"
 
@@ -244,11 +289,6 @@ fi
 
 color_echo "$Cyan" "  File count: ${file_count}"
 
-# create db file
-if [ "${passes_flag}" -ge 1 ]; then
-    touch "./${rebalance_db_file_name}"
-fi
-
 # recursively scan through files and execute "rebalance" procedure
 # in the case of --skip-hardlinks, only find files with links == 1
 if [[ "${skip_hardlinks_flag,,}" == "true"* ]]; then
@@ -256,6 +296,9 @@ if [[ "${skip_hardlinks_flag,,}" == "true"* ]]; then
 else
     find "$root_path" -type f -print0 | while IFS= read -r -d '' file; do rebalance "$file"; done
 fi
+
+# There may be some pending changes as we will almost never hit the interval perfectly - flush it
+persist_database
 
 echo ""
 echo ""


### PR DESCRIPTION
## Preface
Rebalancing is a lengthy process and thus ensuring it can be resumed is rather important. Currently, the code implements
a simple database-like textual file. When script is interrupted and then subsequently restarted, the rebalancing process
can be restarted more-or-less from where it was interrupted.


## The problem
Current solution is great conceptually. However, the implementation suffers from very poor performance due to multiple
factors:

 - spawning multiple processes carries a non-insignificant cost
 - re-reading a good chunk of the database file generates a lot of I/O, even if in-memory
 - the data structure, due ot its simplicity and lack of indexing does not scale well with large number of files

The result of this is a very poor performance during both rebalance and when script needs to be resumed. In the case of
my dataset with ~1M files resume from 500k point took close to 12 hours(!). The performance problems are magnified with
small files being present


## Solutions evaluation
The first optimization I attempted was limiting re-reads for counting. However, this still proven very limiting. The
next idea I tested was using `bash` associative arrays, implementing an in-memory cache persisted occasionally to the
disk. Unfortunately, with 500k+ files the memory usage started to creep into 500-600-800MB range, with more and more
being ostensibly leaked. This shows clearly that bash array were never designed for such a dataset.

I scraped the idea and came back to the drawing board. After ad-hoc testing, I implemented a prototype based on SQLite
database, that is stored in a dedicated file as well. The time for read-save operations were cut by **orders of magnitude**,
despite still launching at least 2 processes for every file. As a next step I implemented a delayed database flush, with
60s timeout, further cutting the db operations time.


## Potential impact for users
The change carries some impact to systems utilizing this project.

 - SQLite database is a binary blob, that is ~30-40% larger than a text file
   - while the database is no longer readable as a text file, the `sqlite3` tool offers an easy interface
   - `README.md` contains a simulated transaction, so that unfamiliar users can easily interact with the db 
 - The usage of SQLite introduces a new dependency on `sqlite3`
   - `sqlite3` is already present on systems that are most likely the target of this script
   - I verified existence of a compatible `sqlite3` binary on TrueNAS SCALE, TrueNAS CORE, macOS 13, as well as Ubuntu
   - Debian doesn't ship with `sqlite3` by default, but package is in the default repo
 - With the delayed-flush of the database to disk, there's a potential of rebalance state being lost
   - at most 60 seconds of the progress can be lost when interrupted
   - re-balancing a file more times than requested doesn't carry a risk, thus I see this as non-issue
 - Previously built databases are no longer usable
   - this PR includes `convert-legacy-db.sh` that handles the migration
   - the script when started in presence of the old database will abort to ensure balancing doesn't start from scratch
     unintentionally
   - documentations has been updated to cover that


## Testing methodology
  - I used my preexisting database file where most of the files will be hit
    - database starting point is being equal for all scripts
    - new version gets `cp rebalance_db.txt_copy rebalance_db.txt ; ./convert-legacy-db.sh` (this takes ~35 seconds)
    - old version gets `cp rebalance_db.txt_copy rebalance_db.txt`
    - in other words, both versions operate on the same logical set of data
  - benchmark pure database operations (commented-out cp/mv/rm)
  - the pool uses HDDs with SSDs for metadata and contains ~500k files
  - command run: `time ./zfs-inplace-rebalancing.sh --checksum false --passes 2 /mnt/testdata > rebalance.log`


## Test results
 - current `.txt`-based database: **29h 14min**
 - SQLite database with per-file flush: **1h 32min**
 - SQLite database with delayed flush every ~60 seconds: **56min**

In other words, it's almost a 30x speed-up :)
There are a few smaller low-hanging fruits for optimization, but I'm tackling one thing at a time.


## WDYT?
...about this PR and the idea itself? Marking as `draft` as of right now as I didn't have a chance to test on FreeBSD
yet.
