### PR TITLE
Remove extraneous flags

### DIFF
--- a/zfs-inplace-rebalancing.sh
+++ b/zfs-inplace-rebalancing.sh
@@ -93,21 +93,19 @@ function rebalance () {
         # Linux
 
         # --reflink=never -- force standard copy (see ZFS Block Cloning)
-        # -a -- keep attributes
-        # -d -- keep symlinks (dont copy target)
+        # -a -- keep attributes, includes -d -- keep symlinks (dont copy target) and 
+        #       -p -- preserve ACLs to
         # -x -- stay on one system
-        # -p -- preserve ACLs too
-        cp --reflink=never -adxp "${file_path}" "${tmp_file_path}"
+        cp --reflink=never -ax "${file_path}" "${tmp_file_path}"
     elif [[ "${OSTYPE,,}" == "darwin"* ]] || [[ "${OSTYPE,,}" == "freebsd"* ]]; then
         # Mac OS
         # FreeBSD
 
-        # -a -- Archive mode.  Same as -RpP.
+        # -a -- Archive mode.  Same as -RpP. Includes preservation of modification 
+        #       time, access time, file flags, file mode, ACL, user ID, and group 
+        #       ID, as allowed by permissions.
         # -x -- File system mount points are not traversed.
-        # -p -- Cause cp to preserve the following attributes of each source file
-        #       in the copy: modification time, access time, file flags, file mode,
-        #       ACL, user ID, and group ID, as allowed by permissions.
-        cp -axp "${file_path}" "${tmp_file_path}"
+        cp -ax "${file_path}" "${tmp_file_path}"
     else
         echo "Unsupported OS type: $OSTYPE"
         exit 1


### PR DESCRIPTION
The flag `a` for cp is also known as archive mode. Specifying flags to preserve attributes or symlinks are extraneous and not needed. In the case of macOS you even specified that this is the case.

While this does not change the behaviour, I think this is cleaner. Accept or deny the pull request as you see fit.

Thank you for this tool, it really helped shave off some used space after my raidz expansion.