### PR TITLE
Replace MD5 with CRC32 for 2x checksum speed

### DIFF
--- a/zfs-inplace-rebalancing.sh
+++ b/zfs-inplace-rebalancing.sh
@@ -137,25 +137,23 @@ function rebalance() {
             # Linux
 
             # file attributes
-            original_md5=$(lsattr "${file_path}")
+            original_checksum=$(lsattr "${file_path}")
             # remove anything after the last space
-            original_md5=${original_md5% *}
+            original_checksum=${original_checksum% *}
             # file permissions, owner, group, size, modification time
-            original_md5="${original_md5} $(stat -c "%A %U %G %s %Y" "${file_path}")"
+            original_checksum="${original_checksum} $(stat -c "%A %U %G %s %Y" "${file_path}")"
             # file content
-            original_md5="${original_md5} $(md5sum -b "${file_path}")"
+            original_checksum="${original_checksum} $(cksum "${file_path}" | awk '{ print $1 }')"
 
 
             # file attributes
-            copy_md5=$(lsattr "${tmp_file_path}")
+            copy_checksum=$(lsattr "${tmp_file_path}")
             # remove anything after the last space
-            copy_md5=${copy_md5% *}
+            copy_checksum=${copy_checksum% *}
             # file permissions, owner, group, size, modification time
-            copy_md5="${copy_md5} $(stat -c "%A %U %G %s %Y" "${tmp_file_path}")"
+            copy_checksum="${copy_checksum} $(stat -c "%A %U %G %s %Y" "${tmp_file_path}")"
             # file content
-            copy_md5="${copy_md5} $(md5sum -b "${tmp_file_path}")"
-            # remove the temporary extension
-            copy_md5=${copy_md5%"${tmp_extension}"}
+            copy_checksum="${copy_checksum} $(cksum "${tmp_file_path}" | awk '{ print $1 }')"
         elif [[ "${OSTYPE}" == "darwin"* ]] || [[ "${OSTYPE}" == "freebsd"* ]]; then
             # Mac OS
             # FreeBSD
@@ -163,25 +161,25 @@ function rebalance() {
             # note: no lsattr on Mac OS or FreeBSD
 
             # file permissions, owner, group size, modification time
-            original_md5="$(stat -f "%Sp %Su %Sg %z %m" "${file_path}")"
+            original_checksum="$(stat -f "%Sp %Su %Sg %z %m" "${file_path}")"
             # file content
-            original_md5="${original_md5} $(md5 -q "${file_path}")"
+            original_checksum="${original_checksum} $(cksum "${file_path}" | awk '{ print $1 }')"
 
             # file permissions, owner, group size, modification time
-            copy_md5="$(stat -f "%Sp %Su %Sg %z %m" "${tmp_file_path}")"
+            copy_checksum="$(stat -f "%Sp %Su %Sg %z %m" "${tmp_file_path}")"
             # file content
-            copy_md5="${copy_md5} $(md5 -q "${tmp_file_path}")"
+            copy_checksum="${copy_checksum} $(cksum "${tmp_file_path}" | awk '{ print $1 }')"
             # remove the temporary extension
-            copy_md5=${copy_md5%"${tmp_extension}"}
+            copy_checksum=${copy_checksum%"${tmp_extension}"}
         else
             echo "Unsupported OS type: $OSTYPE"
             exit 1
         fi
 
-        if [[ "${original_md5}" == "${copy_md5}"* ]]; then
-            color_echo "${Green}" "MD5 OK"
+        if [[ "${original_checksum}" == "${copy_checksum}"* ]]; then
+            color_echo "${Green}" "Checksum OK"
         else
-            color_echo "${Red}" "MD5 FAILED: ${original_md5} != ${copy_md5}"
+            color_echo "${Red}" "Checksum FAILED: ${original_checksum} != ${copy_checksum}"
             exit 1
         fi
     fi

--- a/zfs-inplace-rebalancing.sh
+++ b/zfs-inplace-rebalancing.sh
@@ -169,8 +169,6 @@ function rebalance() {
             copy_checksum="$(stat -f "%Sp %Su %Sg %z %m" "${tmp_file_path}")"
             # file content
             copy_checksum="${copy_checksum} $(cksum "${tmp_file_path}" | awk '{ print $1 }')"
-            # remove the temporary extension
-            copy_checksum=${copy_checksum%"${tmp_extension}"}
         else
             echo "Unsupported OS type: $OSTYPE"
             exit 1


### PR DESCRIPTION
While running this script on a large pool, I noticed that that the MD5 checksum calculation is taking up to 2-3 minutes on the large video project files. By changing to CRC32, I was able to cut down the checksum time by nearly 50% on most files.

For the purpose of adversarial integrity checking, CRC32 is not adequate, and neither is MD5. However, for the purpose of successful copying and corruption checking, CRC32 is adequate. Using MD5 for this script is burning double the CPU cycles for no gain.

Running `./testing.sh` passes all the checks on TrueNAS Scale 24.10, Debian Bookworm, and MacOS Sequoia.