### PR TITLE
1.5x speed increase by using cmp instead of crc32

### DIFF
--- a/zfs-inplace-rebalancing.sh
+++ b/zfs-inplace-rebalancing.sh
@@ -166,7 +166,7 @@ function rebalance() {
             exit 1
         fi
 
-        if [[ "${original_perms}" == "${copy_perms}"* ]] && cmp -s "${file_path}" "${tmp_file_path}"; then
+        if [[ "${original_perms}" == "${copy_perms}"* ]]; then
             color_echo "${Green}" "Attribute and permission check OK"
         else
             color_echo "${Red}" "Attribute and permission check FAILED: ${original_perms} != ${copy_perms}"


### PR DESCRIPTION
After seeing how [switching from MD5 to CRC32 cut down our rebalance time by a couple of weeks](https://github.com/markusressel/zfs-inplace-rebalancing/pull/57), I rethought the checksum process to identify even more speed gains.

Since the goal is to check that the new file is an exact copy of the original file, byte-level comparison should be a good alternative to calculating a checksum for the whole file. A `cmp` operation will likely always be faster than any combination of operations used to calculate a checksum. To my delight, this yielded another 1.5x speed improvement.

```
./zfs-inplace-rebalancing-crc.sh --checksum true --passes 1 ../rebalance-test  43.48s user 39.02s system 116% cpu 1:10.90 total
./zfs-inplace-rebalancing-cmp.sh --checksum true --passes 1 ../rebalance-test  22.27s user 33.38s system 116% cpu 47.771 total
```

Edit: Apologies for the misleading commit message. I was looking only at the user time rather than the total time. The total time shows 1.5x speed improvement.